### PR TITLE
Fourier fixes

### DIFF
--- a/test/build_local_potential.jl
+++ b/test/build_local_potential.jl
@@ -24,7 +24,7 @@ include("silicon_testcases.jl")
         # pot3 back to the PW basis to check we get the 1/|G|^2 behaviour
         pot3 = build_local_potential(pw, pot_coulomb => [[0, 1/8, 0]])
         values_fourier = zeros(ComplexF64, prod(pw.grid_size))
-        r_to_G!(pw, pot3.values_real, values_fourier)
+        r_to_G!(pw, complex(pot3.values_real), values_fourier)
 
         lattice_vector = lattice * [0, 1/8, 0]
         reference = [(4π / pw.unit_cell_volume * pot_coulomb(G)


### PR DESCRIPTION
Save one temp by using in-place FFT, and one pass over the data by using a scaled FFT plan.

I don't understand the factors here, I thought the fourier data was such that `psi = sum cG eG` with the eG orthonormal. Shouldn't there be sqrt(unit_cell_volume) on both sides?