### PR TITLE
More clever expensive assert

### DIFF
--- a/src/DFTK.jl
+++ b/src/DFTK.jl
@@ -10,6 +10,8 @@ using LinearAlgebra
 using StaticArrays
 
 # Core functionality
+include("core/asserting.jl")
+
 export Vec3
 export Mat3
 include("core/constants.jl")

--- a/src/core/asserting.jl
+++ b/src/core/asserting.jl
@@ -1,0 +1,16 @@
+# Control whether expensive assertions are enabled or not
+if get(ENV, "DFTK_PROFILE", "develop") == "performance"
+    assert_expensive_enabled() = false
+else
+    assert_expensive_enabled() = true
+end
+
+macro assert_expensive(expr)
+    esc(:(if $(@__MODULE__).assert_expensive_enabled()
+          @assert($expr) end))
+end
+
+macro assert_expensive(expr, text)
+    esc(:(if $(@__MODULE__).assert_expensive_enabled()
+          @assert($expr, $text) end))
+end

--- a/src/core/constants.jl
+++ b/src/core/constants.jl
@@ -6,10 +6,3 @@ Vec3{T} = SVector{3, T} where T
 
 """The default search location for Pseudopotential data files"""
 DFTK_DATADIR = joinpath(dirname(pathof(DFTK)), "..", "data")
-
-# Special macro to flag expensive assertions, which can be
-# disabled by setting these to nothing
-macro assert_expensive(expr) :(@assert $expr) end
-macro assert_expensive(expr, text) :(@assert($expr, $text)) end
-# macro assert_expensive(expr) nothing end
-# macro assert_expensive(expr, text) nothing end

--- a/src/core/scf.jl
+++ b/src/core/scf.jl
@@ -24,7 +24,7 @@ function iterate_density(ham::Hamiltonian, n_bands, compute_occupation, ρ;
 
     res = lobpcg(ham, n_bands; pot_hartree_values=values_hartree,
                  pot_xc_values=values_xc, guess=Psi, lobpcg_kwargs...)
-    @assert res.converged
+    @assert(res.converged, "Not converged, iterations: $(res.iterations)")
     Psi .= res.X
     occupation = compute_occupation(ham.basis, res.λ, res.X)
     ρ_new = compute_density(pw, res.X, occupation)

--- a/test/silicon_lda.jl
+++ b/test/silicon_lda.jl
@@ -5,5 +5,5 @@ include("silicon_runners.jl")
 end
 @testset "Silicon LDA (small, Float32)" begin
     run_silicon_lda(Float32, Ecut=7, test_tol=0.03, n_ignored=1, grid_size=19, scf_tol=1e-4,
-                    lobpcg_tol=3e-5, n_noconv_check=1)
+                    lobpcg_tol=5e-5, n_noconv_check=1)
 end


### PR DESCRIPTION
- By default `assert_expensive` is enabled
- Can be disabled by setting `DFTK.enabled_assert_expensive() = false`
- Can be disabled by setting environment variable `DFTK_PROFILE` to `performance`.

Happy to bikeshed about names and mechanisms :smile:.