### PR TITLE
Fixes for 1D systems

### DIFF
--- a/examples/silicon.jl
+++ b/examples/silicon.jl
@@ -45,9 +45,9 @@ kcoords, ksymops = bzmesh_ir_wedge(kgrid, lattice, composition...)
 fft_size = determine_grid_size(lattice, Ecut)
 basis = PlaneWaveBasis(model, fft_size, Ecut, kcoords, ksymops)
 
-# Run SCF, note Silicon metal is an insulator, so we will assume that we do not need
-# all bands here. This will cause warnings in some models, because e.g. in the
-# :reduced_hf model silicon is a metal
+# Run SCF. Note Silicon is a semiconductor, so we use an insulator
+# occupation scheme. This will cause warnings in some models, because
+# e.g. in the :reduced_hf model silicon is a metal
 n_bands_scf = Int(model.n_electrons / 2)
 ham = Hamiltonian(basis, guess_gaussian_sad(basis, composition...))
 scfres = self_consistent_field!(ham, n_bands_scf, tol=1e-6)

--- a/src/core/Density.jl
+++ b/src/core/Density.jl
@@ -9,22 +9,23 @@ fourier(ρ::Density) = ρ._fourier
 
 function density_from_real(basis, ρ_real)
     T = real(eltype(ρ_real))
-    if maximum(imag(ρ_real)) > 100 * eps(T)
-        @warn "Large norm(imag(ρ))" norm_imag=maximum(imag(ρ_real))
-    end
-
+    check_density_real(ρ_real)
     Density(basis, real(ρ_real), r_to_G(basis, ρ_real .+ 0im))
 end
 
 function density_from_fourier(basis, ρ_fourier)
     ρ_real = G_to_r(basis, ρ_fourier .+ 0im)
     T = real(eltype(ρ_real))
-    if maximum(imag(ρ_real)) > 100 * eps(T)
-        @warn "Large norm(imag(ρ))" norm_imag=maximum(imag(ρ_real))
-    end
-
+    check_density_real(ρ_real)
     Density(basis, real(ρ_real), ρ_fourier .+ 0im)
 end
 
 # This assumes CPU arrays
-density_zero(basis::PlaneWaveBasis{T}) where T = density_from_real(basis, zeros(T, basis.fft_size))
+Density(basis::PlaneWaveBasis{T}) where T = density_from_real(basis, zeros(T, basis.fft_size))
+
+check_density_real(ρ::Density) = check_density(real(ρ))
+function check_density_real(ρreal)
+    if norm(imag(ρreal)) > 100 * eps(real(eltype(ρreal)))
+        @warn "Large imag(ρ)" norm_imag=norm(imag(ρreal))
+    end
+end

--- a/src/core/Density.jl
+++ b/src/core/Density.jl
@@ -1,3 +1,5 @@
+# Stores the density in both real and fourier space. Should be read-only once created.
+
 struct Density
     basis
     _real     # Real-space component

--- a/src/core/Hamiltonian.jl
+++ b/src/core/Hamiltonian.jl
@@ -2,7 +2,7 @@ using LinearAlgebra
 
 # Data structure and functionality for a one-particle Hamiltonian
 
-struct Hamiltonian
+mutable struct Hamiltonian
     basis::PlaneWaveBasis  # Discretized model
     density                # The electron density used to build this Hamiltonian
     kinetic                # Discretized kinetic operator
@@ -55,6 +55,7 @@ Update Hamiltonian in-place
 function update_hamiltonian!(ham::Hamiltonian, ρ::Density)
     basis = ham.basis
     model = basis.model
+    ham.density = ρ
     model.build_hartree(basis, nothing, ham.pot_hartree; ρ=ρ)
     model.build_xc(basis, nothing, ham.pot_xc; ρ=ρ)
     if ham.pot_local !== nothing

--- a/src/core/Hamiltonian.jl
+++ b/src/core/Hamiltonian.jl
@@ -26,7 +26,7 @@ function Hamiltonian(basis::PlaneWaveBasis{T}, ρ=nothing) where T
     # TODO This assumes CPU array
     potarray(p::Density) = similar(fourier(p))
     potarray(::Nothing) = zeros(Complex{T}, basis.fft_size)
-    ρzero = something(ρ, density_zero(basis))
+    ρzero = something(ρ, Density(basis))
 
     _, pot_external = model.build_external(basis, nothing, potarray(ρ))
     _, pot_nonlocal = model.build_nonlocal(basis, nothing, potarray(ρ))
@@ -78,10 +78,6 @@ function update_energies!(energies, ham::Hamiltonian, Psi, occupation, ρ=nothin
     ρ === nothing && (ρ = compute_density(ham.basis, Psi, occupation))
 
     energies[:Kinetic] = energy_term_operator(ham.kinetic, Psi, occupation)
-    if ham.pot_external !== nothing
-        dVol = model.unit_cell_volume / prod(basis.fft_size)
-        energies[:PotExternal] = real(sum(real(ρ) .* ham.pot_external) * dVol)
-    end
 
     function insert_energy!(key, builder; kwargs...)
         energy, _ = builder(basis, Ref{valtype(energies)}(0), nothing; kwargs...)

--- a/src/core/compute_density.jl
+++ b/src/core/compute_density.jl
@@ -28,9 +28,7 @@ function compute_partial_density(pw, kpt, Ψk, occupation)
 
     # Check sanity of the density (real, positive and normalized)
     T = real(eltype(ρk_real))
-    if maximum(imag(ρk_real)) > 100 * eps(T)
-        @warn "Large norm(imag(ρ))" norm_imag=maximum(imag(ρk_real))
-    end
+    check_density_real(ρk_real)
     if all(occupation .> 0)
         minimum(real(ρk_real)) < 0 && @warn("Negative ρ detected",
                                             min_ρ=minimum(real(ρk_real)))

--- a/src/core/self_consistent_field.jl
+++ b/src/core/self_consistent_field.jl
@@ -7,6 +7,7 @@ function iterate_density!(ham::Hamiltonian, n_bands, ρ=nothing; Psi=nothing,
                           compute_occupation=find_occupation_around_fermi,
                           eigensolver=lobpcg_hyper)
     # Update Hamiltonian from ρ
+    ## TODO this changes the potentials in ham, and is problematic if we want to do potential mixing
     ρ !== nothing && update_hamiltonian!(ham, ρ)
 
     # Update Psi from Hamiltonian (ask for a few more bands than the ones we need)

--- a/src/core/term_xc.jl
+++ b/src/core/term_xc.jl
@@ -81,8 +81,7 @@ function DensityDervatives(basis, max_derivative::Integer, ρ)
     @assert model.spin_polarisation == :none "Only spin_polarisation == :none implemented."
     function ifft(x)
         tmp = G_to_r(basis, x)
-        @assert(maximum(abs.(imag(tmp))) < 100 * eps(real(eltype(x))),
-                "Imaginary part too large $(maximum(imag(tmp)))")
+        check_density_real(tmp)
         real(tmp)
     end
 

--- a/src/utils/bzmesh.jl
+++ b/src/utils/bzmesh.jl
@@ -38,7 +38,12 @@ function bzmesh_ir_wedge(kgrid_size, lattice, composition...; tol_symmetry=1e-5)
     # Ask spglib for symmetry operations and for irreducible mesh
     spg_symops = spglib.get_symmetry(spglib_cell(lattice, composition...),
                                      symprec=tol_symmetry)
-    spg_symops !== nothing || error("Could not get symmetry")
+
+    # If spglib does not find symmetries give an error
+    spg_symops !== nothing || error(
+        "spglib failed to get the symmetries. Check your lattice, or use a uniform BZ mesh."
+    )
+
     mapping, grid = spglib.get_stabilized_reciprocal_mesh(
         kgrid_size, spg_symops["rotations"], is_shift=[0, 0, 0], is_time_reversal=true
     )

--- a/src/utils/determine_grid_size.jl
+++ b/src/utils/determine_grid_size.jl
@@ -14,17 +14,15 @@ represented in the basis ``B_k = \{G : |G + k|^2/2 \leq E_\text{cut}\}``,
 function determine_grid_size(lattice::AbstractMatrix, Ecut; supersampling=2, tol=1e-8, ensure_smallprimes=true)
     # See the documentation about the grids for details on the construction of C_ρ
     cutoff_Gsq = 2 * supersampling^2 * Ecut
-    fft_size = [norm(lattice[:, i]) / 2π * sqrt(cutoff_Gsq) for i in 1:3]
-
-    # Convert fft_size into integers by rounding up unless the value is only
-    # `tol` larger than an actual integer.
-    fft_size = ceil.(Int, fft_size .- tol)
+    Gmax= [norm(lattice[:, i]) / 2π * sqrt(cutoff_Gsq) for i in 1:3]
+    # Round up
+    Gmax = ceil.(Int, Gmax .- tol)
 
     # Optimise FFT grid size: Make sure the number factorises in small primes only
     if ensure_smallprimes
-        Vec3([nextprod([2, 3, 5], 2gs + 1) for gs in fft_size])
+        Vec3([nextprod([2, 3, 5], 2gs + 1) for gs in Gmax])
     else
-        Vec3([2gs+1 for gs in fft_size])
+        Vec3([2gs+1 for gs in Gmax])
     end
 end
 function determine_grid_size(model::Model, Ecut; kwargs...)

--- a/src/utils/guess_gaussian_sad.jl
+++ b/src/utils/guess_gaussian_sad.jl
@@ -20,7 +20,6 @@ function guess_gaussian_sad(basis, composition...)
     density_from_fourier(basis, ρ / model.unit_cell_volume)
 end
 
-
 ## TODO give the formula in real space in the doc, and clarify that the atomic density is that of the valence electrons
 @doc raw"""
 Get the atomic decay length for an atom with `n_elec_core` core


### PR DESCRIPTION
spglib segfaults for lattices with a very small (<1e-8) dimension in one direction. Am I doing something wrong? If not we should report it as a bug.