### PR TITLE
Use seeds for RNGs to make consecutive SCF runs reproducible

### DIFF
--- a/src/DFTK.jl
+++ b/src/DFTK.jl
@@ -43,6 +43,7 @@ include("common/quadrature.jl")
 include("common/hankel.jl")
 include("common/hydrogenic.jl")
 include("common/derivatives.jl")
+include("common/random.jl")
 
 export PspHgh
 export PspUpf

--- a/src/common/random.jl
+++ b/src/common/random.jl
@@ -1,0 +1,7 @@
+"""
+Default random number generator for DFTK.
+Deterministic across Julia runs and repeated calls unlike `Random.default_rng()`.
+"""
+function default_rng()
+    Xoshiro(42)
+end

--- a/src/orbitals.jl
+++ b/src/orbitals.jl
@@ -79,8 +79,9 @@ function unsafe_unpack_ψ(x, sizes_ψ)
 end
 unpack_ψ(x, sizes_ψ) = deepcopy(unsafe_unpack_ψ(x, sizes_ψ))
 
-function random_orbitals(basis::PlaneWaveBasis{T}, kpt::Kpoint, howmany::Integer) where {T}
+function random_orbitals(basis::PlaneWaveBasis{T}, kpt::Kpoint, howmany::Integer;
+                         rng=default_rng()) where {T}
     orbitals = similar(G_vectors(basis), Complex{T}, length(G_vectors(basis, kpt)), howmany)
-    randn!(Xoshiro(42), orbitals)
+    randn!(rng, orbitals)
     ortho_qr(orbitals)
 end

--- a/src/scf/direct_minimization.jl
+++ b/src/scf/direct_minimization.jl
@@ -75,6 +75,7 @@ function direct_minimization(basis::PlaneWaveBasis{T};
                              optim_method=Optim.LBFGS,
                              alphaguess=LineSearches.InitialStatic(),
                              linesearch=LineSearches.BackTracking(),
+                             rng=default_rng(),
                              kwargs...) where {T}
     if mpi_nprocs() > 1
         # need synchronization in Optim
@@ -89,7 +90,7 @@ function direct_minimization(basis::PlaneWaveBasis{T};
     Nk = length(basis.kpoints)
 
     if isnothing(ψ)
-        ψ = [random_orbitals(basis, kpt, n_bands) for kpt in basis.kpoints]
+        ψ = [random_orbitals(basis, kpt, n_bands; rng) for kpt in basis.kpoints]
     end
     occupation = [filled_occ * ones(T, n_bands) for _ = 1:Nk]
 

--- a/test/reproducibility.jl
+++ b/test/reproducibility.jl
@@ -1,0 +1,17 @@
+@testitem "Reproducibility of SCF runs" setup=[TestCases] begin
+using DFTK
+silicon = TestCases.silicon
+
+model = model_DFT(silicon.lattice, silicon.atoms, silicon.positions; functionals=LDA())
+Ecut = 15
+kgrid = [2, 2, 2]
+
+basis = PlaneWaveBasis(model; Ecut, kgrid)
+scfres1 = self_consistent_field(basis; tol=1e-7)
+
+scfres2 = self_consistent_field(basis; tol=1e-7)
+
+# Should be exactly equal if the computation is reproducible, no need for epsilons.
+@assert scfres1.history_Etot == scfres2.history_Etot
+@assert scfres1.history_Δρ == scfres2.history_Δρ
+end


### PR DESCRIPTION
This PR makes SCFs reproducible (for a fixed Manifest.toml, possibly requiring no MPI as well) by using a fixed seed for the used pseudorandom number generators. If there is a concern over the random numbers being "helpful" in rare cases, I can look into allowing a seed or rng to be passed through `self_consistent_field` for expert usage.