### PR TITLE
Fix inconsistency between CPU and GPU in LOBPCG

### DIFF
--- a/src/eigen/linalg.jl
+++ b/src/eigen/linalg.jl
@@ -8,7 +8,7 @@ end
     [dot(A[:, i], B[:, i]) for i = 1:size(A, 2)]
 end
 
-# Returns a vector of real(dot(A[:, i], M, B[:, i])), for all columns of
+# Returns a vector of dot(A[:, i], M, B[:, i]), for all columns of
 # A, B, and matrix M
 @views function columnwise_dots(A::AbstractArray{T}, M, B::AbstractArray{T}) where {T}
     [dot(A[:, i], M, B[:, i]) for i = 1:size(A, 2)]


### PR DESCRIPTION
Remove the `real` conversion in the CPU version of `columnwise_dots`. It is inconsistent with the GPU version and the code prior to #1068. It is also unnecessary, since `real` is already explicitly taken when that matters.

Spotted by @Technici4n 