### PR TITLE
Symmetry correction for antiferromagnetic ordering

### DIFF
--- a/src/symmetry.jl
+++ b/src/symmetry.jl
@@ -92,8 +92,14 @@ on each of the atoms. The symmetries are determined using spglib.
         elseif spin_polarization == :collinear
             rotations, translations, spin_flips = Spglib.get_symmetry_with_site_tensors(
                 cell, tol_symmetry)
-            # Keep only the symmetries that don't flip the spins (see PR #1144).
+            # Keep only the symmetries that don't flip the spins
             rotations[spin_flips.==1], translations[spin_flips.==1]
+            # Taking into account the symmetries that flip spins here would mean detecting 
+            # antiferromagnetic order (where the down orbitals are the up orbitals 
+            # translated by half a cell) and optimizing by computing only the up channel of 
+            # the orbitals and building the density by symmetry. So, the density has two 
+            # components, but the orbitals have only one spin channel.
+            # This would cut runtime by a factor 2.
         end
     catch e
         if e isa Spglib.SpglibError


### PR DESCRIPTION
Correction of symmetries in collinear spin:

Previously, 'symmetry_operations' returned the same symmetries for supercells with equal or opposite magnetic moments on different atoms, which did not allow antiferromagnetic solutions to exist. This behavior comes from 'get_symmetry_with_collinear_spin', which seems to consider only the norm of the magnetic moments.

This PR fixes the issue by discarding symmetries that involve a spin flip (identified by 'get_symmetry_with_site_tensors' but not by 'get_symmetry_with_collinear_spin'). This is a quick fix, these discarded symmetries could maybe be properly taken into account.