### PR TITLE
Fix DivideAndConquer in Julia 1.12

### DIFF
--- a/src/eigen/lobpcg_hyper_impl.jl
+++ b/src/eigen/lobpcg_hyper_impl.jl
@@ -151,7 +151,7 @@ end
     # For versions < 1.12, since we mainly care about eigenvectors being orthogonal
     # we re-orthogonalise explicitly.
     @static if VERSION >= v"1.12"
-        values, vectors = eigen(XAX; alg=DivideAndConquer())
+        values, vectors = eigen(XAX; alg=LinearAlgebra.DivideAndConquer())
         return vectors[:, 1:N], values[1:N]
     else
         values, vectors = eigen(XAX)


### PR DESCRIPTION
Julia 1.12.0 is now used by the "Julia latest" workflow in CI even though no announcement was made yet (see https://julialang-s3.julialang.org/bin/versions.json).

Turns out that `DivideAndConquer` is not exported, so we need to prefix it by `LinearAlgebra.`. The `>= v"1.12"` check is false for pre-releases, which is why this only started failing now.