### PR TITLE
ForwardDiff tests: Use Val(:tag) in Dual type

### DIFF
--- a/test/forwarddiff.jl
+++ b/test/forwarddiff.jl
@@ -389,6 +389,7 @@ end
                       functionals=LDA(), temperature=1e-3, smearing=Smearing.Gaussian())
     
     # Make silicon dual model
+    # We need to call the `Tag` constructor to trigger the `ForwardDiff.tagcount`
     T = typeof(ForwardDiff.Tag(Val(:mytag), Float64))
     x_dual = ForwardDiff.Dual{T}(1.0, 1.0)
     model_dual = Model(model; lattice=x_dual * model.lattice)


### PR DESCRIPTION
```julia
julia> using ForwardDiff

julia> T1 = typeof(ForwardDiff.Tag(:t1, Float64))
ForwardDiff.Tag{Symbol, Float64}

julia> T2 = typeof(ForwardDiff.Tag(:t2, Float64))
ForwardDiff.Tag{Symbol, Float64}

julia> d1 = ForwardDiff.Dual{T1}(1.0, 2.0)
Dual{ForwardDiff.Tag{Symbol, Float64}}(1.0,2.0)

julia> d2 = ForwardDiff.Dual{T2}(2.0, 3.0)
Dual{ForwardDiff.Tag{Symbol, Float64}}(2.0,3.0)

julia> d1 * d2  # Perturbation confusion
Dual{ForwardDiff.Tag{Symbol, Float64}}(2.0,7.0)
```
whereas when using Val(:tag):
```julia
julia> T1 = typeof(ForwardDiff.Tag(Val(:t1), Float64))
ForwardDiff.Tag{Val{:t1}, Float64}

julia> T2 = typeof(ForwardDiff.Tag(Val(:t2), Float64))
ForwardDiff.Tag{Val{:t2}, Float64}

julia> d1 = ForwardDiff.Dual{T1}(1.0, 2.0)
Dual{ForwardDiff.Tag{Val{:t1}, Float64}}(1.0,2.0)

julia> d2 = ForwardDiff.Dual{T2}(2.0, 3.0)
Dual{ForwardDiff.Tag{Val{:t2}, Float64}}(2.0,3.0)

julia> d1 * d2
Dual{ForwardDiff.Tag{Val{:t2}, Float64}}(Dual{ForwardDiff.Tag{Val{:t1}, Float64}}(2.0,4.0),Dual{ForwardDiff.Tag{Val{:t1}, Float64}}(3.0,6.0))
```