### PR TITLE
Woraround for brittle SVD on AMD GPUs

### DIFF
--- a/ext/DFTKAMDGPUExt.jl
+++ b/ext/DFTKAMDGPUExt.jl
@@ -13,6 +13,11 @@ function LinearAlgebra.cholesky(A::Hermitian{T, <:AMDGPU.ROCArray}) where {T}
     LinearAlgebra.Cholesky(Acopy, A.uplo, info)
 end
 
+# Temporary workaround for SVD. See https://github.com/JuliaGPU/AMDGPU.jl/issues/837
+function LinearAlgebra.LAPACK.gesdd!(jobz::Char, A::AMDGPU.ROCArray{T}) where {T}
+    AMDGPU.rocSOLVER.gesvd!(jobz, jobz, A)
+end
+
 # Ensure precompilation is only performed if an AMD GPU is available
 if AMDGPU.functional()
     # Precompilation block with a basic workflow


### PR DESCRIPTION
When running on AMD GPUs, we often get an error of the type:

```
ERROR: LoadError: ArgumentError: invalid argument #4 to LAPACK call
Stacktrace:
  [1] chklapackerror
    @ /capstor/scratch/cscs/abussy/dftk_beverin/julia-1.10.10/share/julia/stdlib/v1.10/LinearAlgebra/src/lapack.jl:38 [inlined]
  [2] gesdd!(job::Char, A::ROCArray{Float64, 2, AMDGPU.Runtime.Mem.HIPBuffer})
    @ LinearAlgebra.LAPACK /capstor/scratch/cscs/abussy/dftk_beverin/julia-1.10.10/share/julia/stdlib/v1.10/LinearAlgebra/src/lapack.jl:1668
  [3] svdvals!
    @ /capstor/scratch/cscs/abussy/dftk_beverin/julia-1.10.10/share/julia/stdlib/v1.10/LinearAlgebra/src/svd.jl:217 [inlined]
  [4] svdvals(A::ROCArray{Float64, 2, AMDGPU.Runtime.Mem.HIPBuffer})
    @ LinearAlgebra /capstor/scratch/cscs/abussy/dftk_beverin/julia-1.10.10/share/julia/stdlib/v1.10/LinearAlgebra/src/svd.jl:242
  [5] cond(A::ROCArray{Float64, 2, AMDGPU.Runtime.Mem.HIPBuffer}, p::Int64)
    @ LinearAlgebra /capstor/scratch/cscs/abussy/dftk_beverin/julia-1.10.10/share/julia/stdlib/v1.10/LinearAlgebra/src/dense.jl:1556
  [6] cond(A::ROCArray{Float64, 2, AMDGPU.Runtime.Mem.HIPBuffer})
    @ LinearAlgebra /capstor/scratch/cscs/abussy/dftk_beverin/julia-1.10.10/share/julia/stdlib/v1.10/LinearAlgebra/src/dense.jl:1555
  [7] (::DFTK.AndersonAcceleration)(xₙ::ROCArray{…}, αₙ::Float64, Pfxₙ::ROCArray{…})
    @ DFTK /capstor/scratch/cscs/abussy/dftk_beverin/DFTK.jl/src/scf/anderson.jl:81
```

This PR overwrites LAPACK's `gesdd!` (divide and conquer SVD) method with rocSOLVER's `gesvd!` (generic SVD) for ROCArrays. This is a temporary workaround until AMDGPU is fixed upstream (see https://github.com/JuliaGPU/AMDGPU.jl/issues/837)