### PR TITLE
ForwardDiff wrappers to reduce compilation time

### DIFF
--- a/test/forwarddiff.jl
+++ b/test/forwarddiff.jl
@@ -1,6 +1,8 @@
 # Wrappers around ForwardDiff to fix tags and reduce compilation time.
 # Warning: fixing types without care can lead to perturbation confusion,
-# this should only be used within the testing framework.
+# this should only be used within the testing framework. Risk of perturbation
+# confusion arises when nested derivatives of different functions are taken
+# with a fixed tag. Only use these wrappers at the top-level call.
 @testmodule ForwardDiffWrappers begin
 using ForwardDiff
 export tagged_derivative, tagged_gradient, tagged_jacobian
@@ -258,7 +260,7 @@ end
 
     function compute_nth_derivative(n, f, x)
         (n == 0) && return f(x)
-        tagged_derivative(x -> compute_nth_derivative(n - 1, f, x), x)
+        ForwardDiff.derivative(x -> compute_nth_derivative(n - 1, f, x), x)
     end
 
     @testset "Avoid NaN from exp-overflow for large x" begin


### PR DESCRIPTION
This PR introduces wrappers around ForwardDiff differentiation calls in order to reduce compilation time.

When a FD derivative is requested, a `Dual{T,V,N}` type is created and propagated through all relevant functions, where `T` is a unique tag. As a result, large compilation time is spent specializing on the exact `Dual{T,V,N}` type.

When a second FD call takes place in the same session, a `Dual{T2,V,N}` is created, and the above process is repeated.

However, when only the tag changes and `V, N` remain the same, the actual compiled code could be reused (but it's not)! The wrappers introduced here allow reusing compile code by imposing a custom (fixed by default) tag.

Applications:
- Speed-up the `forwarddiff.jl` tests (from 537 s to 345 s on my laptop)
- Speed-up workflows with repeated FD calls (e.g. cell optimization)
- Potentially enables differentiation in a pre-compile workflow

Notes:
FD generates different tags at each call in order to prevent perturbation confusion. This is a very safe behavior, at the expense of large compilation times. As long as nested differentiations use different tags (either by explicitly passing a new tag, or by calling FD directly), the current approach is also safe.

Pre-compiling a specific FD call is also possible by wrapping it into a function, e.g:
```
get_deriv_ε1() = ForwardDiff.derivative(ε1 -> compute_force(ε1, 0.0), 0.0)
# warm-up
derivative_ε1 = get_deriv_ε1()
# second call uses precompiled code specific to get_deriv_ε1
derivative_ε1 = get_deriv_ε1()
```
but the proposed wrappers are way more general and transferable.

Mainly inspired by https://github.com/SciML/OrdinaryDiffEq.jl/pull/1545