### PR TITLE
Add some timings for refinement

### DIFF
--- a/src/DFTK.jl
+++ b/src/DFTK.jl
@@ -259,6 +259,9 @@ function precompilation_workflow(lattice, atoms, positions, magnetic_moments;
     scfres = self_consistent_field(basis; ρ=ρ0, tol=1e-2, maxiter=3, callback=identity)
     compute_forces_cart(scfres)
 
+    # Clear precompilation section timings
+    reset_timer!(timer)
+
     nothing
 end
 
@@ -278,4 +281,10 @@ end
         precompilation_workflow(lattice, atoms, positions, magnetic_moments)
     end
 end
+
+function __init__()
+    # Reset timer; otherwise the starting time is the time of precompilation
+    reset_timer!(timer)
+end
+
 end # module DFTK

--- a/src/scf/newton.jl
+++ b/src/scf/newton.jl
@@ -48,7 +48,7 @@ using LinearMaps
 #  Compute the gradient of the energy, projected on the space tangent to ψ, that
 #  is to say H(ψ)*ψ - ψ*λ where λ is the set of Rayleigh coefficients associated
 #  to the ψ.
-function compute_projected_gradient(basis::PlaneWaveBasis, ψ, occupation)
+@timing function compute_projected_gradient(basis::PlaneWaveBasis, ψ, occupation)
     ρ = compute_density(basis, ψ, occupation)
     H = energy_hamiltonian(basis, ψ, occupation; ρ).ham
 


### PR DESCRIPTION
I also reset the timer 1) at the end of precompilation and 2) when loading the package. The former clears the sections measured during precompilation, and the latter resets the starting time when DFTK is loaded. Resetting in `__init__` would be sufficient, but it seems a bit silly to save the precompilation timings.