### PR TITLE
Update JULIA_DEPOT_PATH suggestion

### DIFF
--- a/docs/src/tricks/compute_clusters.md
+++ b/docs/src/tricks/compute_clusters.md
@@ -27,7 +27,7 @@ the `JULIA_DEPOT_PATH` to be a subdirectory of `/scratch`.
 **EPFL scitas.**
 On scitas the right thing to do is to insert
 ```
-export JULIA_DEPOT_PATH="$JULIA_DEPOT_PATH:/scratch/$USER/.julia"
+export JULIA_DEPOT_PATH="/scratch/$USER/.julia"
 ```
 into your `~/.bashrc`.
 


### PR DESCRIPTION
Leaving a leading empty entry will I think make Julia prefer the default location (see https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_DEPOT_PATH), but I have not verified this.