### PR TITLE
Fix flaky tests in hessian.jl

### DIFF
--- a/test/hessian.jl
+++ b/test/hessian.jl
@@ -155,7 +155,7 @@ end
 
     model = model_DFT(silicon.lattice, silicon.atoms, silicon.positions;
                       functionals=[:lda_xc_teter93])
-    basis = PlaneWaveBasis(model; Ecut=3, kgrid=(3, 3, 3), fft_size=[9, 9, 9])
+    basis = PlaneWaveBasis(model; Ecut=3, kgrid=(3, 3, 3))
     scfres = self_consistent_field(basis; tol=10)
 
     rhs = compute_projected_gradient(basis, scfres.ψ, scfres.occupation)
@@ -188,7 +188,7 @@ end
 
     model = model_DFT(magnesium.lattice, magnesium.atoms, magnesium.positions;
                       functionals=[:lda_xc_teter93], magnesium.temperature)
-    basis = PlaneWaveBasis(model; Ecut=5, kgrid=(3, 3, 3), fft_size=[9, 9, 9])
+    basis = PlaneWaveBasis(model; Ecut=5, kgrid=(3, 3, 3))
     nbandsalg = AdaptiveBands(basis.model; occupation_threshold=1e-10)
     scfres = self_consistent_field(basis; tol=1e-12, nbandsalg)
 


### PR DESCRIPTION
The changed test was previously flaky, as found by @antoine-levitt in https://github.com/JuliaMolSim/DFTK.jl/pull/1239#issuecomment-3790266892

I changed two things
- [x] Using normalized test orbitals `\phi` instead of bare Gaussian-random variables (unbounded); This makes sense since we target an absolute tolerance here
- [x] removed fft_size=[9,9,9], which is too small for Ecut=3 here; this is crucial for self-adjointness tests (I am keeping the solve_ΩplusK_split self-adjointness testtol for at 1e-7 for now.. but it is actually much tighter with these new setup fixes, at ~1e-11 or so at given settings, which is reassuring)