### PR TITLE
Bump version to 0.7.21

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DFTK"
 uuid = "acf6eb54-70d9-11e9-0013-234b7a5f5337"
-version = "0.7.20"
+version = "0.7.21"
 authors = ["Michael F. Herbst <info@michael-herbst.com>", "Antoine Levitt <antoine.levitt@inria.fr>"]
 
 [deps]


### PR DESCRIPTION
To make a release for PseudopotentialIO 0.3.1 (follow up to #1160); I ran into it today accidentally having PseudopotentialIO 0.1.1 installed and load_psp not working on a new upf file