### PR TITLE
Extend MPI tests to ForwardDiff

### DIFF
--- a/src/workarounds/forwarddiff_rules.jl
+++ b/src/workarounds/forwarddiff_rules.jl
@@ -255,7 +255,7 @@ end
         ham_dual * scfres.ψ
     end
     # Implicit differentiation
-    response.verbose && println("Solving response problem")
+    response.verbose && mpi_master(basis_primal.comm_kpts) && println("Solving response problem")
     δresults = ntuple(N) do α
         δHextψ = [ForwardDiff.partials.(δHextψk, α) for δHextψk in Hψ_dual]
         δtemperature = ForwardDiff.partials(basis_dual.model.temperature, α)

--- a/test/forwarddiff/geometry.jl
+++ b/test/forwarddiff/geometry.jl
@@ -76,7 +76,7 @@ function run_test(; architecture)
 end
 end
 
-@testitem "Force derivatives using ForwardDiff" tags=[:dont_test_mpi, :minimal] #=
+@testitem "Force derivatives using ForwardDiff" tags=[:minimal] #=
     =#    setup=[TestCases, ForwardDiffWrappers, ForceDerivatives] begin
     using DFTK
     ForceDerivatives.run_test(; architecture=DFTK.CPU())
@@ -147,7 +147,7 @@ function run_test(; architecture)
 end
 end
 
-@testitem "Anisotropic strain sensitivity using ForwardDiff" tags=[:dont_test_mpi, :minimal] #=
+@testitem "Anisotropic strain sensitivity using ForwardDiff" tags=[:minimal] #=
     =#    setup=[TestCases, ForwardDiffWrappers, StrainSensitivity] begin
     using DFTK
     StrainSensitivity.run_test(; architecture=DFTK.CPU())
@@ -250,7 +250,7 @@ function run_test()
 end
 end
 
-@testitem "Symmetries broken by perturbation are filtered out" tags=[:dont_test_mpi, :minimal] #=
+@testitem "Symmetries broken by perturbation are filtered out" tags=[:minimal] #=
     =#    setup=[FilterBrokenSymmetries] begin
     using DFTK
     FilterBrokenSymmetries.run_test()
@@ -301,7 +301,7 @@ function run_test(; architecture)
 end
 end
 
-@testitem "Symmetry-breaking perturbation using ForwardDiff" tags=[:dont_test_mpi, :minimal] #=
+@testitem "Symmetry-breaking perturbation using ForwardDiff" tags=[:minimal] #=
     =#    setup=[TestCases, ForwardDiffWrappers, SymmetryBreakingPerturbation] begin
     using DFTK
    SymmetryBreakingPerturbation.run_test(; architecture=DFTK.CPU())

--- a/test/forwarddiff/parameters.jl
+++ b/test/forwarddiff/parameters.jl
@@ -48,7 +48,7 @@ function run_test(; architecture)
 end
 end
 
-@testitem "scfres PSP sensitivity using ForwardDiff" tags=[:dont_test_mpi, :minimal] #=
+@testitem "scfres PSP sensitivity using ForwardDiff" tags=[:minimal] #=
     =#    setup=[TestCases, ForwardDiffWrappers, PspSensitivity] begin
     using DFTK
     PspSensitivity.run_test(; architecture=DFTK.CPU())
@@ -101,7 +101,7 @@ function run_test(; architecture)
 end
 end
 
-@testitem "Functional force sensitivity using ForwardDiff" tags=[:dont_test_mpi, :minimal] #=
+@testitem "Functional force sensitivity using ForwardDiff" tags=[:minimal] #=
     =#    setup=[TestCases, ForwardDiffWrappers, ForceSensitivity] begin
     using DFTK
     ForceSensitivity.run_test(; architecture=DFTK.CPU())
@@ -152,7 +152,7 @@ function run_test(; architecture)
 end
 end
 
-@testitem "LocalNonlinearity sensitivity using ForwardDiff" tags=[:dont_test_mpi, :minimal] #=
+@testitem "LocalNonlinearity sensitivity using ForwardDiff" tags=[:minimal] #=
     =#    setup=[ForwardDiffWrappers, LocalNonlinearitySensitivity] begin
     using DFTK
     LocalNonlinearitySensitivity.run_test(; architecture=DFTK.CPU())
@@ -200,7 +200,7 @@ function run_test(; architecture)
 end
 end
 
-@testitem "Test scfres dual has the same params as scfres primal" tags=[:dont_test_mpi, :minimal] #=
+@testitem "Test scfres dual has the same params as scfres primal" tags=[:minimal] #=
     =#    setup=[TestCases, ScfresParameterConsistency] begin
     using DFTK
     ScfresParameterConsistency.run_test(; architecture=DFTK.CPU())
@@ -249,7 +249,7 @@ function run_test(; architecture)
 end
 end
 
-@testitem "ForwardDiff wrt temperature" tags=[:dont_test_mpi, :minimal] #=
+@testitem "ForwardDiff wrt temperature" tags=[:minimal] #=
     =#    setup=[ForwardDiffWrappers, TemperatureSensitivity] begin
     using DFTK
     TemperatureSensitivity.run_test(; architecture=DFTK.CPU())


### PR DESCRIPTION
The response code just works with MPI, and all ForwardDiff tests pass when run in parallel. To me, there is no good reason not to run these tests when testing with MPI.