### PR TITLE
Fix `architecture(x::AbstractArray)` function

### DIFF
--- a/src/architecture.jl
+++ b/src/architecture.jl
@@ -48,6 +48,6 @@ function memory_usage(::CPU)
 end
 
 """
-Returns the architecture of the given array.
+Returns the architecture of the given array, independent of the element type.
 """
-architecture(x::AbstractArray) = x isa AbstractGPUArray ? GPU{typeof(x)}() : CPU()
+architecture(x::AbstractArray) = x isa AbstractGPUArray ? GPU{typeof(x).name.wrapper}() : CPU()


### PR DESCRIPTION
PR #1163 introduced the `architecture(x::AbstractArray)` function. It simplifies the transfer of data to and from the GPU when the `basis` and its `architecture` field are not available.

Unfortunately, it is faulty, as the element type of the input array is carried over. Currently, the function may change the type of an array, and not simply transfer it to the GPU:
```
using CUDA
using DFTK


template = CuArray(randn(ComplexF64, 1))
arch     = DFTK.architecture(template)

a_cpu   = randn(Float64, 100)
a_gpu   = DFTK.to_device(arch, a_cpu)

@assert eltype(a_cpu) == eltype(a_gpu) # fails, because a_gpu is an array of ComplexF64
```

This PR fixes the function, such that it has the expected behavior.