### PR TITLE
solve_ΩplusK: Fix printing only on the master rank

### DIFF
--- a/src/response/hessian.jl
+++ b/src/response/hessian.jl
@@ -82,7 +82,7 @@ function ResponseCallback()
     ResponseCallback(Ref(zero(UInt64)))
 end
 function (cb::ResponseCallback)(info)
-    mpi_master(info.basis.comm_kpts) && return info  # Only print on master
+    mpi_master(info.basis.comm_kpts) || return info  # Only print on master
 
     if info.stage == :finalize
         info.converged || @warn "solve_ΩplusK not converged."


### PR DESCRIPTION
Regression introduced in https://github.com/JuliaMolSim/DFTK.jl/commit/a1308a1fa8e6e3ab92de4c1e40c77e75865a3738.