### PR TITLE
fix save_scfres fallback signature

### DIFF
--- a/src/scf/scfres.jl
+++ b/src/scf/scfres.jl
@@ -79,7 +79,7 @@ Keyword arguments:
     save_ψ = something(save_ψ, (ext == :jld2))
     save_scfres(Val(ext), filename, scfres; save_ψ, save_ρ, extra_data, compress)
 end
-function save_scfres(::Any, filename::AbstractString, ::NamedTuple; kwargs...)
+function save_scfres(::Val, filename::AbstractString, ::NamedTuple; kwargs...)
     error("The extension $(last(splitext(filename))) is currently not available. " *
           "A required package (e.g. JLD2 or JSON3) is not yet loaded.")
 end


### PR DESCRIPTION
calling `save_scfres(:json, ...)` with a plain symbol `:json` would hit the fallback and produce a misleading error "json extension not available". With `::Val`, it correctly raises a `MethodError` instead.