### PR TITLE
Add non-periodic system support with truncated Coulomb

### DIFF
--- a/src/DFTK.jl
+++ b/src/DFTK.jl
@@ -69,6 +69,8 @@ include("SymOp.jl")
 
 export Smearing
 export Model
+export is_wavefunctions_periodic, is_electrostatics_periodic
+export n_periodic_electrostatics, is_fully_periodic_electrostatics
 export FFTGrid
 export MonkhorstPack, ExplicitKpoints
 export PlaneWaveBasis

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -21,6 +21,20 @@ struct Model{T <: Real, VT <: Real}
     unit_cell_volume::T
     recip_cell_volume::T
 
+    # Boundary conditions along each of the three lattice directions.
+    # Each entry is one of:
+    #     true                  -- fully periodic
+    #     :wavefunctions_only   -- wavefunctions are periodic (standard plane-wave
+    #                              Bloch basis), but the electrostatics is treated
+    #                              as isolated via the truncated Coulomb method of
+    #                              Rozzi et al. (Phys. Rev. B 73, 205119 (2006))
+    #     false                 -- fully isolated (also implies isolated electrostatics)
+    #                              Reserved for a future implementation of non-periodic
+    #                              wavefunctions; currently accepted but for electrostatic
+    #                              purposes behaves identically to :wavefunctions_only.
+    # Isolated directions must be orthogonal to periodic ones.
+    periodicity::NTuple{3, Union{Bool, Symbol}}
+
     # Computations can be performed at fixed `n_electrons` (`n_electrons` Int, `εF` nothing),
     # or fixed Fermi level (expert option, `n_electrons` nothing, `εF` T)
     n_electrons::Union{Int, Nothing}
@@ -142,6 +156,7 @@ function Model(lattice::AbstractMatrix{Tstatic},
                spin_polarization=determine_spin_polarization(magnetic_moments),
                symmetries=default_symmetries(lattice, atoms, positions, magnetic_moments,
                                              spin_polarization, terms),
+               periodicity=(true, true, true),
                ) where {Tstatic <: Real}
     # # a bit convoluted because kwargs can't determine type parameters
     T = promote_type(Tstatic, typeof(temperature))
@@ -179,6 +194,28 @@ function Model(lattice::AbstractMatrix{Tstatic},
     _is_well_conditioned(lattice[1:n_dim, 1:n_dim]) || @warn (
         "Your lattice is badly conditioned, the computation is likely to fail.")
 
+    # Validate periodicity specification and check orthogonality between
+    # isolated and periodic directions.
+    periodicity = NTuple{3, Union{Bool, Symbol}}(periodicity)
+    for p in periodicity
+        p === true || p === false || p === :wavefunctions_only || error(
+            "Each entry of `periodicity` must be `true`, `false`, or " *
+            "`:wavefunctions_only`, got $(repr(p)).")
+    end
+    # An "isolated" direction (either fully isolated or wavefunctions_only, i.e.
+    # anything that is not `true`) must be orthogonal to every periodic direction.
+    for i = 1:3, j = 1:3
+        i == j && continue
+        periodicity[i] === true && continue        # i is periodic
+        periodicity[j] !== true && continue        # j is not periodic -- no constraint
+        if !iszero(dot(lattice[:, i], lattice[:, j]))
+            error("Periodicity check failed: lattice vector $i is marked " *
+                  "$(repr(periodicity[i])) but is not orthogonal to periodic " *
+                  "lattice vector $j. Isolated directions must be orthogonal " *
+                  "to periodic ones.")
+        end
+    end
+
     # Note: In the 1D or 2D case, the volume is the length/surface
     inv_lattice       = compute_inverse_lattice(lattice)
     recip_lattice     = compute_recip_lattice(lattice)
@@ -213,7 +250,7 @@ function Model(lattice::AbstractMatrix{Tstatic},
 
     Model{T,value_type(T)}(model_name,
                            lattice, recip_lattice, n_dim, inv_lattice, inv_recip_lattice,
-                           unit_cell_volume, recip_cell_volume,
+                           unit_cell_volume, recip_cell_volume, periodicity,
                            n_electrons, εF, spin_polarization, n_spin, temperature, smearing,
                            atoms, positions, atom_groups, terms, symmetries)
 end
@@ -294,6 +331,7 @@ function Model{T}(model::Model;
           model.smearing,
           model.εF,
           model.spin_polarization,
+          model.periodicity,
           symmetries,
           # Can be safely disabled: this has been checked for model
           disable_electrostatics_check=true,
@@ -310,6 +348,39 @@ end
 
 Base.convert(::Type{Model{T}}, model::Model{T}) where {T}    = model
 Base.convert(::Type{Model{U}}, model::Model{T}) where {T, U} = Model{U}(model)
+
+"""
+Return `true` if wavefunctions are treated as periodic along lattice direction `i`
+(i.e. standard Bloch plane-wave basis). Currently both `true` and `:wavefunctions_only`
+imply periodic wavefunctions.
+"""
+is_wavefunctions_periodic(p) = (p === true) || (p === :wavefunctions_only)
+is_wavefunctions_periodic(model::Model, i::Integer) =
+    is_wavefunctions_periodic(model.periodicity[i])
+
+"""
+Return `true` if the electrostatics (Hartree, local ionic and Ewald terms) are
+periodic along lattice direction `i`. Only `true` yields periodic electrostatics;
+`:wavefunctions_only` and `false` both mean the electrostatics is treated as
+isolated along that direction, via the truncated Coulomb method of
+Rozzi et al. (Phys. Rev. B 73, 205119 (2006)).
+"""
+is_electrostatics_periodic(p) = (p === true)
+is_electrostatics_periodic(model::Model, i::Integer) =
+    is_electrostatics_periodic(model.periodicity[i])
+
+"""
+Number of directions along which the electrostatics is treated as periodic.
+Returns an integer in `0:3`.
+"""
+n_periodic_electrostatics(model::Model) =
+    count(is_electrostatics_periodic, model.periodicity)
+
+"""
+Return `true` if the full electrostatics of the model is treated as periodic
+(the default 3D-periodic case).
+"""
+is_fully_periodic_electrostatics(model::Model) = n_periodic_electrostatics(model) == 3
 
 normalize_magnetic_moment(::Nothing)::Vec3{Float64}          = (0, 0, 0)
 normalize_magnetic_moment(mm::Number)::Vec3{Float64}         = (0, 0, mm)

--- a/src/input_output.jl
+++ b/src/input_output.jl
@@ -35,6 +35,9 @@ function Base.show(io::IO, ::MIME"text/plain", model::Model)
     end
 
     println(io)
+    if !is_fully_periodic_electrostatics(model)
+        showfieldln(io, "periodicity", model.periodicity)
+    end
     if !isnothing(model.n_electrons)
         showfieldln(io, "num. electrons", model.n_electrons)
     end
@@ -89,6 +92,7 @@ function todict!(dict, model::Model)
     dict["atomic_positions_cart"] = vector_red_to_cart.(model, model.positions)
     !isnothing(model.εF)          && (dict["εF"]          = model.εF)
     !isnothing(model.n_electrons) && (dict["n_electrons"] = model.n_electrons)
+    dict["periodicity"] = collect(string.(model.periodicity))
 
     family = pseudofamily(model)
     if isnothing(family)

--- a/src/terms/ewald.jl
+++ b/src/terms/ewald.jl
@@ -4,25 +4,42 @@ import SpecialFunctions: erfc
 Ewald term: electrostatic energy per unit cell of the array of point
 charges defined by `model.atoms` in a uniform background of
 compensating charge yielding net neutrality.
+For non-periodic electrostatics (any direction with `periodicity != true`)
+the ion-ion interaction is computed as a bare direct pair sum with no
+periodic images and no compensating background.
 """
 Base.@kwdef struct Ewald
     η = nothing  # Parameter used for the splitting 1/r ≡ erf(η·r)/r + erfc(η·r)/r
                  # (or nothing if autoselected)
 end
-(ewald::Ewald)(basis) = TermEwald(basis; η=something(ewald.η, default_η(basis.model.lattice)))
+function (ewald::Ewald)(basis)
+    model = basis.model
+    if is_fully_periodic_electrostatics(model)
+        TermEwald(basis; η=something(ewald.η, default_η(basis.model.lattice)))
+    else
+        TermEwald(basis; direct=true)
+    end
+end
 
 struct TermEwald{T} <: TermLinear
     energy::T                # precomputed energy
     forces::Vector{Vec3{T}}  # and forces
-    η::T                     # Parameter used for the splitting
-    #                          1/r ≡ erf(η·r)/r + erfc(η·r)/r
+    η::T                     # Ewald splitting parameter (zero for direct-sum mode)
 end
 @timing "precomp: Ewald" function TermEwald(basis::PlaneWaveBasis{T};
-                                            η=default_η(basis.model.lattice)) where {T}
+                                            η=default_η(basis.model.lattice),
+                                            direct=false) where {T}
     model = basis.model
     charges = charge_ionic.(model.atoms)
-    (; energy, forces) = energy_forces_ewald(model.lattice, charges, model.positions; η)
-    TermEwald(energy, forces, η)
+    if direct
+        # Non-periodic: bare direct pair sum, no images, no background charge.
+        (; energy, forces) = energy_forces_ewald_direct(T, model.lattice,
+                                                        charges, model.positions)
+        TermEwald(energy, forces, zero(T))
+    else
+        (; energy, forces) = energy_forces_ewald(model.lattice, charges, model.positions; η)
+        TermEwald(energy, forces, η)
+    end
 end
 
 function ene_ops(term::TermEwald, basis::PlaneWaveBasis, ψ, occupation; kwargs...)
@@ -175,6 +192,32 @@ function energy_forces_ewald(lattice::AbstractArray{T}, charges, positions, q,
                              ph_disp; kwargs...) where{T}
     S = promote_type(complex(T), eltype(ph_disp[1]))
     energy_forces_ewald(S, lattice, charges, positions, q, ph_disp; kwargs...)
+end
+
+"""
+Compute the direct (non-periodic) ion-ion electrostatic energy and forces.
+Only the pair sum within a single unit cell is computed (no images, no
+compensating background). This is appropriate when the electrostatics is
+treated as isolated in all directions.
+"""
+function energy_forces_ewald_direct(T, lattice, charges, positions)
+    n = length(positions)
+    energy = zero(T)
+    forces = [zero(Vec3{T}) for _ = 1:n]
+    for i = 1:n, j = 1:n
+        i == j && continue
+        ri_cart = lattice * positions[i]
+        rj_cart = lattice * positions[j]
+        Δr = ri_cart - rj_cart
+        dist = norm(Δr)
+        energy += charges[i] * charges[j] / dist
+        # Force on i in reduced coordinates: F_red = L^T * F_cart
+        # F_cart = -dE/d(ri_cart), dE/d(ri_cart) = -Zi*Zj * Δr / dist^3
+        F_cart = charges[i] * charges[j] * Δr / dist^3
+        forces[i] += lattice' * F_cart
+    end
+    # Divide by 2 to remove double-counting
+    (; energy=energy / 2, forces=forces)
 end
 
 # TODO: See if there is a way to express this with AD.

--- a/src/terms/hartree.jl
+++ b/src/terms/hartree.jl
@@ -28,17 +28,30 @@ struct TermHartree <: TermNonlinear
 end
 function compute_poisson_green_coeffs(basis::PlaneWaveBasis{T}, scaling_factor;
                                       q=zero(Vec3{T})) where {T}
-    recip_lattice = basis.model.recip_lattice
+    model = basis.model
+    recip_lattice = model.recip_lattice
 
-    # Solving the Poisson equation ΔV = -4π ρ in Fourier space
-    # is multiplying elementwise by 4π / |G|^2.
-    poisson_green_coeffs = map(G -> 4T(π) / sum(abs2, recip_lattice * (G + q)),
-                               G_vectors(basis))
-    if iszero(q)
-        # Compensating charge background => Zero DC.
-        GPUArraysCore.@allowscalar poisson_green_coeffs[1] = 0
-        # Symmetrize Fourier coeffs to have real iFFT.
-        enforce_real!(poisson_green_coeffs, basis)
+    if is_fully_periodic_electrostatics(model)
+        # Solving the periodic Poisson equation ΔV = -4π ρ in Fourier space
+        # is multiplying elementwise by 4π / |G|^2 (with neutralising background,
+        # i.e. dropping G=0).
+        poisson_green_coeffs = map(G -> 4T(π) / sum(abs2, recip_lattice * (G + q)),
+                                   G_vectors(basis))
+        if iszero(q)
+            # Compensating charge background => Zero DC.
+            GPUArraysCore.@allowscalar poisson_green_coeffs[1] = 0
+            # Symmetrize Fourier coeffs to have real iFFT.
+            enforce_real!(poisson_green_coeffs, basis)
+        end
+    else
+        # Non-periodic directions: use the Rozzi et al. truncated Coulomb kernel.
+        # The kernel is finite (and generally non-zero) at G=0 in the 0D case.
+        poisson_green_coeffs = map(G_vectors(basis)) do G
+            truncated_coulomb_fourier(recip_lattice * (G + q), model)
+        end
+        if iszero(q)
+            enforce_real!(poisson_green_coeffs, basis)
+        end
     end
     scaling_factor .* poisson_green_coeffs
 end

--- a/src/terms/local.jl
+++ b/src/terms/local.jl
@@ -128,6 +128,13 @@ function compute_local_potential(basis::PlaneWaveBasis{T}; positions=basis.model
         end
     end
 
+    # Apply the Rozzi truncated Coulomb correction to the long-range tail of
+    # each atom's local potential whenever the electrostatics is not fully
+    # periodic. This replaces -Z_a/r by -Z_a · v_c(r) at long range.
+    if !is_fully_periodic_electrostatics(basis.model)
+        add_truncated_coulomb_ionic_correction!(pot, basis, positions, q)
+    end
+
     pot_fourier = reshape(pot, basis.fft_size)
     if iszero(q)
         enforce_real!(pot, basis)  # Symmetrize coeffs to have real iFFT
@@ -136,11 +143,77 @@ function compute_local_potential(basis::PlaneWaveBasis{T}; positions=basis.model
         return ifft(basis, pot_fourier)
     end
 end
+
+"""
+Add the Rozzi truncated Coulomb correction to a fully-assembled periodic
+atomic local potential `pot` (flattened Fourier coefficients in `sqrt(Ω)`
+normalisation). This in-place modifies `pot` so that each atom's long-range
+``-Z_a/r`` tail is replaced by the truncated Coulomb ``-Z_a · v_c(r)`` tail.
+
+Only `q = 0` is currently supported.
+"""
+function add_truncated_coulomb_ionic_correction!(pot, basis::PlaneWaveBasis{T},
+                                                 positions, q) where {T}
+    model = basis.model
+    iszero(q) || error("Truncated Coulomb corrections with q ≠ 0 are not yet " *
+                       "supported (no phonon support yet).")
+
+    # G_vectors returns a 3D array; flatten to 1D so we can index linearly.
+    Gs_cpu = vec(to_cpu(G_vectors(basis)))  # Vector{Vec3{Int}}, length = prod(fft_size)
+    recip_lattice = model.recip_lattice
+
+    # Per-G correction factor Z_a * (4π/|G|² - v_c(G)), evaluated for each
+    # atomic group (all atoms in a group share the same ionic charge). At G=0
+    # we substitute the correct finite limit: V_short_a(0) - Z_a · v_c(0),
+    # with V_short_a(0) = eval_psp_energy_correction(T, el_a).
+    vc0 = truncated_coulomb_fourier(zero(Vec3{T}), model)
+    Ω = model.unit_cell_volume
+
+    # Precompute per-G correction factor (same for all atoms of the same group)
+    # to avoid redundant kernel evaluations. correction_cpu is 1D, same length as Gs_cpu.
+    n_G = length(Gs_cpu)
+    correction_cpu = zeros(Complex{T}, n_G)
+
+    for (igroup, group) in enumerate(model.atom_groups)
+        element = model.atoms[first(group)]
+        Za = T(charge_ionic(element))
+        Vshort0 = T(eval_psp_energy_correction(T, element))
+
+        # Per-G correction form factor for this element group
+        fG_group = Vector{T}(undef, n_G)
+        for iG = 1:n_G
+            Gcart = recip_lattice * Gs_cpu[iG]
+            Gsq = sum(abs2, Gcart)
+            if iszero(Gsq)
+                fG_group[iG] = Vshort0 - Za * vc0
+            else
+                vc = truncated_coulomb_fourier(Gcart, model)
+                fG_group[iG] = Za * (4T(π) / Gsq - vc)
+            end
+        end
+
+        # Accumulate structure-factor-weighted correction for each atom
+        for idx in group
+            r = positions[idx]
+            for iG = 1:n_G
+                G = Gs_cpu[iG]
+                correction_cpu[iG] += cis2pi(-dot(G, r)) * fG_group[iG] / sqrt(Ω)
+            end
+        end
+    end
+
+    pot .+= to_device(basis.architecture, correction_cpu)
+    pot
+end
 (::AtomicLocal)(basis::PlaneWaveBasis{T}) where {T} =
     TermAtomicLocal(compute_local_potential(basis))
 
 function compute_forces(::TermAtomicLocal, basis::PlaneWaveBasis{T}, ψ, occupation;
                         ρ, kwargs...) where {T}
+    # TODO: for non-periodic electrostatics the correction term added in
+    # compute_local_potential (add_truncated_coulomb_ionic_correction!) also
+    # contributes to the forces. This derivative is not yet implemented and
+    # forces will be approximate in the truncated-Coulomb case.
     S = promote_type(T, real(eltype(ψ[1])))
     forces_local(S, basis, ρ, zero(Vec3{T}))
 end
@@ -182,6 +255,9 @@ end
 
 @views function compute_dynmat(::TermAtomicLocal, basis::PlaneWaveBasis{T}, ψ, occupation;
                                ρ, δρs, q=zero(Vec3{T}), kwargs...) where {T}
+    !is_fully_periodic_electrostatics(basis.model) && error(
+        "Phonon dynamical matrices with truncated Coulomb electrostatics " *
+        "are not yet implemented.")
     S = complex(T)
     model = basis.model
     positions = model.positions

--- a/src/terms/psp_correction.jl
+++ b/src/terms/psp_correction.jl
@@ -7,10 +7,18 @@ struct PspCorrection end
 struct TermPspCorrection{T} <: TermLinear
     energy::T  # precomputed energy
 end
-function TermPspCorrection(basis::PlaneWaveBasis)
+function TermPspCorrection(basis::PlaneWaveBasis{T}) where {T}
     model = basis.model
     if model.n_dim != 3 && any(attype isa ElementPsp for attype in model.atoms)
         error("The use of pseudopotentials is only sensible for 3D systems.")
+    end
+    if !is_fully_periodic_electrostatics(model)
+        # In the truncated-Coulomb treatment the G=0 component of the ionic
+        # potential is set to the correct finite value V_short(0) - Z·v_c(0)
+        # (including V_short(0) explicitly), so the periodic correction that
+        # accounts for the missing G=0 term must be dropped to avoid
+        # double-counting.
+        return TermPspCorrection(zero(T))
     end
     TermPspCorrection(energy_psp_correction(model))
 end

--- a/src/terms/terms.jl
+++ b/src/terms/terms.jl
@@ -52,6 +52,8 @@ breaks_symmetries(::Any) = false
 
 include("kinetic.jl")
 
+include("truncated_coulomb.jl")
+
 include("local.jl")
 breaks_symmetries(::ExternalFromReal) = true
 breaks_symmetries(::ExternalFromFourier) = true

--- a/src/terms/truncated_coulomb.jl
+++ b/src/terms/truncated_coulomb.jl
@@ -1,0 +1,112 @@
+# Truncated Coulomb kernels for non-periodic electrostatics, following
+#
+#     C. A. Rozzi, D. Varsano, A. Marini, E. K. U. Gross, A. Rubio,
+#     "Exact Coulomb cutoff technique for supercell calculations",
+#     Phys. Rev. B 73, 205119 (2006).
+#     https://arxiv.org/abs/cond-mat/0601031
+#
+# These functions return the Fourier transform V_c(G) of a Coulomb interaction
+# that has been truncated in the directions of the simulation cell that are
+# marked as non-periodic in `model.periodicity`. V_c(G) replaces the usual
+# 4π/|G|² kernel in the Hartree and ionic-local electrostatics.
+#
+# Four cases arise depending on how many lattice directions carry periodic
+# electrostatics (as returned by `n_periodic_electrostatics(model)`):
+#
+#   * 3 — fully periodic: V_c(G) = 4π/|G|² (standard Ewald convention with
+#     compensating background, i.e. V_c(0) = 0).
+#
+#   * 2 — 2D slab: one isolated direction, orthogonal to the periodic plane.
+#     V_c(G) = 4π/|G|² (1 - exp(-|G_∥| R) cos(G_z R)), with R half the length
+#     of the isolated lattice vector.  G=0 set to 0 (compensating background
+#     in the periodic plane).
+#
+#   * 1 — 1D wire: NOT YET IMPLEMENTED. Will require Bessel-function formulas
+#     with special handling of the G_∥=0 limit (Rozzi et al., eqs. 21–22).
+#
+#   * 0 — 0D fully isolated molecule: spherical cutoff at radius R equal to
+#     half the minimum lattice edge length. V_c(G) = 4π/|G|² (1 - cos(|G| R))
+#     for G ≠ 0 and V_c(0) = 2π R² (the finite limit).
+#
+# For case 0, the cell is required to be orthogonal (this is enforced by the
+# `Model` constructor when all directions are non-periodic).
+
+"""
+Compute the truncation radius `R` used by the Rozzi truncated Coulomb method
+for a given `Model`. Chosen automatically as half the minimum edge length
+over the non-electrostatically-periodic lattice directions. Returns `zero(T)`
+for fully periodic models.
+"""
+function truncated_coulomb_radius(model::Model{T}) where {T}
+    n_periodic_electrostatics(model) == 3 && return zero(T)
+    lengths = T[norm(model.lattice[:, i])
+                for i = 1:3 if !is_electrostatics_periodic(model, i)]
+    return minimum(lengths) / 2
+end
+
+"""
+Fourier-space value of the truncated Coulomb kernel V_c(G_cart) at the given
+Cartesian G vector for the given model. Returns zero for G=0 in the 3D/2D
+(compensating-background) cases and a finite value for the 0D case.
+
+This implements the Rozzi et al. formulas for 0D (spherical cutoff) and 2D
+(slab cutoff). The 3D case falls back to the standard 4π/|G|² kernel. The 1D
+wire case is not yet implemented and will raise an error.
+"""
+function truncated_coulomb_fourier(G_cart::AbstractVector{T}, model::Model) where {T}
+    n_per = n_periodic_electrostatics(model)
+    Gsq = sum(abs2, G_cart)
+
+    if n_per == 3
+        # Fully periodic: standard Coulomb with neutralising background (G=0 set to 0).
+        iszero(Gsq) && return zero(T)
+        return 4T(π) / Gsq
+
+    elseif n_per == 0
+        # Fully isolated 0D: spherical cutoff at R.
+        R = T(truncated_coulomb_radius(model))
+        if iszero(Gsq)
+            return 2T(π) * R^2
+        else
+            Gnorm = sqrt(Gsq)
+            return 4T(π) * (1 - cos(Gnorm * R)) / Gsq
+        end
+
+    elseif n_per == 2
+        # 2D slab: find the isolated direction (orthogonal to the periodic plane).
+        iiso = findfirst(i -> !is_electrostatics_periodic(model, i), 1:3)
+        # Unit vector along the isolated lattice direction (assumed orthogonal
+        # to the periodic ones by the Model constructor checks).
+        aiso_cart = model.lattice[:, iiso]
+        Liso = norm(aiso_cart)
+        R = T(Liso / 2)
+        ẑ = aiso_cart / Liso
+        Gz = dot(G_cart, ẑ)
+        Gpar = sqrt(max(Gsq - Gz^2, zero(T)))
+        if iszero(Gsq)
+            # Compensating background in the periodic plane: drop DC.
+            return zero(T)
+        else
+            return 4T(π) * (1 - exp(-Gpar * R) * cos(Gz * R)) / Gsq
+        end
+
+    else  # n_per == 1
+        error("Truncated Coulomb for 1D-periodic wire geometries is not yet " *
+              "implemented. TODO: add the Bessel-function formulas from " *
+              "Rozzi et al. (2006), with special treatment of the G_∥=0 limit.")
+    end
+end
+
+"""
+Build a 3D array of the Rozzi truncated Coulomb Green's function coefficients
+for every `G` vector in `basis`, optionally shifted by `q`. The layout matches
+`G_vectors(basis)`.
+"""
+function truncated_coulomb_green_coeffs(basis::PlaneWaveBasis{T};
+                                        q=zero(Vec3{T})) where {T}
+    model = basis.model
+    recip_lattice = model.recip_lattice
+    coeffs = map(G -> truncated_coulomb_fourier(recip_lattice * (G + q), model),
+                 G_vectors(basis))
+    coeffs
+end

--- a/test/truncated_coulomb.jl
+++ b/test/truncated_coulomb.jl
@@ -1,0 +1,218 @@
+@testitem "Truncated Coulomb: Model periodicity field" tags=[:minimal] begin
+    using DFTK
+    using LinearAlgebra
+
+    # Orthogonal cubic cell - fully periodic (default)
+    lattice = 10 * I(3)
+    atoms = [ElementCoulomb(:H)]
+    positions = [[0.5, 0.5, 0.5]]
+    model = Model(lattice, atoms, positions; terms=[Kinetic()], n_electrons=1,
+                  spin_polarization=:spinless)
+    @test model.periodicity == (true, true, true)
+    @test is_fully_periodic_electrostatics(model)
+    @test n_periodic_electrostatics(model) == 3
+
+    # Fully isolated electrostatics
+    model_iso = Model(lattice, atoms, positions;
+                      terms=[Kinetic()], n_electrons=1, spin_polarization=:spinless,
+                      symmetries=false,
+                      periodicity=(:wavefunctions_only, :wavefunctions_only, :wavefunctions_only))
+    @test model_iso.periodicity == (:wavefunctions_only, :wavefunctions_only, :wavefunctions_only)
+    @test !is_fully_periodic_electrostatics(model_iso)
+    @test n_periodic_electrostatics(model_iso) == 0
+    @test is_wavefunctions_periodic(model_iso, 1)
+
+    # `false` is accepted (reserved for future fully-isolated wavefunctions)
+    model_false = Model(lattice, atoms, positions;
+                        terms=[Kinetic()], n_electrons=1, spin_polarization=:spinless,
+                        symmetries=false, periodicity=(false, false, false))
+    @test model_false.periodicity == (false, false, false)
+
+    # Mixed (2D slab): isolated direction must be orthogonal to the two periodic ones
+    lat2D = diagm([10.0, 12.0, 20.0])
+    model_2D = Model(lat2D, atoms, positions;
+                     terms=[Kinetic()], n_electrons=1, spin_polarization=:spinless,
+                     symmetries=false, periodicity=(true, true, :wavefunctions_only))
+    @test n_periodic_electrostatics(model_2D) == 2
+
+    # Non-orthogonal lattice should error when mixing periodic and isolated directions
+    lat_nort = [10.0 5.0 0.0; 0.0 10.0 0.0; 0.0 0.0 10.0]
+    @test_throws ErrorException Model(lat_nort, atoms, positions;
+                                      terms=[Kinetic()], n_electrons=1,
+                                      spin_polarization=:spinless, symmetries=false,
+                                      periodicity=(true, :wavefunctions_only, true))
+
+    # Invalid periodicity value should error
+    @test_throws ErrorException Model(lattice, atoms, positions;
+                                      terms=[Kinetic()], n_electrons=1,
+                                      spin_polarization=:spinless, symmetries=false,
+                                      periodicity=(:bad, true, true))
+end
+
+@testitem "Truncated Coulomb: kernel values" tags=[:minimal] begin
+    using DFTK
+    using DFTK: truncated_coulomb_fourier, truncated_coulomb_radius
+    using LinearAlgebra
+
+    L = 20.0
+    lattice = L * I(3)
+    atoms = [ElementCoulomb(:H)]
+    positions = [[0.5, 0.5, 0.5]]
+
+    # 3D periodic: 4π/G²
+    model_3D = Model(lattice, atoms, positions; terms=[Kinetic()], n_electrons=1,
+                     spin_polarization=:spinless, symmetries=false)
+    G1 = [2π/L, 0.0, 0.0]
+    @test truncated_coulomb_fourier(G1, model_3D) ≈ 4π / sum(abs2, G1)
+    @test truncated_coulomb_fourier(zeros(3), model_3D) ≈ 0.0  # neutralising background
+
+    # 0D isolated: 4π/G² * (1 - cos(|G|R)), G=0 → 2πR²
+    model_0D = Model(lattice, atoms, positions; terms=[Kinetic()], n_electrons=1,
+                     spin_polarization=:spinless, symmetries=false,
+                     periodicity=(:wavefunctions_only, :wavefunctions_only, :wavefunctions_only))
+    R = truncated_coulomb_radius(model_0D)
+    @test R ≈ L / 2  # automatic choice: half minimum box dimension
+
+    Gnorm = 2π / L
+    Gc = [Gnorm, 0.0, 0.0]
+    vc = truncated_coulomb_fourier(Gc, model_0D)
+    @test vc ≈ 4π * (1 - cos(Gnorm * R)) / Gnorm^2
+
+    vc0 = truncated_coulomb_fourier(zeros(3), model_0D)
+    @test vc0 ≈ 2π * R^2
+
+    # 2D slab: 4π/G²*(1 - exp(-G_∥ R) cos(G_z R))
+    lattice_slab = diagm([10.0, 10.0, 20.0])
+    model_slab = Model(lattice_slab, atoms, positions; terms=[Kinetic()], n_electrons=1,
+                       spin_polarization=:spinless, symmetries=false,
+                       periodicity=(true, true, :wavefunctions_only))
+    R_slab = 10.0  # half of 20 Bohr in the isolated z direction
+    Gc_slab = [2π/10, 0.0, 2π/20]  # G with both in-plane and out-of-plane components
+    Gsq = sum(abs2, Gc_slab)
+    Gpar = Gc_slab[1]
+    Gz   = Gc_slab[3]
+    vc_slab = truncated_coulomb_fourier(Gc_slab, model_slab)
+    @test vc_slab ≈ 4π / Gsq * (1 - exp(-Gpar * R_slab) * cos(Gz * R_slab))
+end
+
+@testitem "Truncated Coulomb: direct Ewald pair sum" tags=[:minimal] begin
+    using DFTK
+    using DFTK: energy_forces_ewald_direct
+    using LinearAlgebra
+
+    # H₂: 2 protons at distance 1.4 Bohr — simple repulsive ion-ion test
+    L = 20.0
+    lattice = L * I(3)
+    d = 1.4
+    positions = [[0.5 - d/2/L, 0.5, 0.5], [0.5 + d/2/L, 0.5, 0.5]]
+    charges = [1.0, 1.0]
+
+    (; energy, forces) = energy_forces_ewald_direct(Float64, lattice, charges, positions)
+    # Ion-ion Coulomb: Z²/d = 1/1.4
+    @test energy ≈ 1.0 / d atol=1e-12
+
+    # Forces in reduced coordinates: convert to Cartesian via inv(L')
+    # F_red = L' * F_cart  →  F_cart = L'^{-T} * F_red = F_red / L  for cubic
+    F1_cart = forces[1] / L
+    @test F1_cart[1] < 0                       # atom 1 pushed left (−x) by atom 2
+    @test abs(F1_cart[1]) ≈ 1.0 / d^2 atol=1e-12
+end
+
+@testitem "Truncated Coulomb: ionic potential G=0 value" tags=[:minimal] begin
+    using DFTK
+    using DFTK: compute_local_potential, truncated_coulomb_fourier, truncated_coulomb_radius
+    using LinearAlgebra
+
+    L = 20.0
+    lattice = L * I(3)
+    # Single H atom (Z=1) at cell centre
+    atoms = [ElementCoulomb(:H)]
+    positions = [[0.5, 0.5, 0.5]]
+    model = Model(lattice, atoms, positions;
+                  terms=[Kinetic(), AtomicLocal()],
+                  n_electrons=1, spin_polarization=:spinless, symmetries=false,
+                  periodicity=(:wavefunctions_only, :wavefunctions_only, :wavefunctions_only))
+    basis = PlaneWaveBasis(model; Ecut=5.0, kgrid=(1, 1, 1))
+
+    # Compute the truncated ionic potential in real space, then FFT back.
+    V_real = compute_local_potential(basis)
+    V_fourier = fft(basis, V_real)
+
+    R = truncated_coulomb_radius(model)         # = L/2 = 10 Bohr
+    vc0 = truncated_coulomb_fourier(zeros(3), model)  # = 2π R²
+    Ω = model.unit_cell_volume
+    # At G=0 the ionic potential for a truncated Coulomb is ∫V dr / sqrt(Ω)
+    # = -Z * vc0 / sqrt(Ω)  (since V_short(G=0) = 0 for bare Coulomb)
+    expected_G0 = -1.0 * vc0 / sqrt(Ω)
+    @test real(V_fourier[1]) ≈ expected_G0 atol=1e-8
+
+    # Verify that the periodic (non-truncated) potential has V_ion(G=0) = 0
+    model_per = Model(lattice, atoms, positions;
+                      terms=[Kinetic(), AtomicLocal()],
+                      n_electrons=1, spin_polarization=:spinless, symmetries=false)
+    basis_per = PlaneWaveBasis(model_per; Ecut=5.0, kgrid=(1, 1, 1))
+    V_per = compute_local_potential(basis_per)
+    V_per_fourier = fft(basis_per, V_per)
+    @test abs(V_per_fourier[1]) < 1e-12   # zero by compensating-background convention
+end
+
+@testitem "Truncated Coulomb: isolated dipole convergence" tags=[:slow] begin
+    using DFTK
+    using LinearAlgebra
+
+    # Two Gaussian atoms with different potential strengths create an asymmetric
+    # external potential and hence a non-zero electronic dipole moment. We verify
+    # that the SCF energy and dipole converge rapidly with box size under the
+    # truncated Coulomb treatment (no spurious image interactions).
+    #
+    # For ElementGaussian the ionic charge is zero, so only the Hartree
+    # (electron-electron) truncation matters here.
+
+    function compute_energy_dipole(L; Ecut=4.0,
+                                   periodicity=(:wavefunctions_only,
+                                                :wavefunctions_only,
+                                                :wavefunctions_only))
+        d = 1.4   # atomic separation (Bohr)
+        lattice = L * I(3)
+        # Stronger Gaussian (α=1.5) left of centre, weaker (α=0.5) right → electron
+        # density concentrated slightly left → dipole relative to centre is negative
+        atoms = [ElementGaussian(1.5, 0.5; symbol=:A),
+                 ElementGaussian(0.5, 0.5; symbol=:B)]
+        positions = [[0.5 - d/(2L), 0.5, 0.5],
+                     [0.5 + d/(2L), 0.5, 0.5]]
+
+        # ElementGaussian has charge_ionic=0; disable the charge-neutrality check
+        # and set n_electrons manually.
+        model = Model(lattice, atoms, positions;
+                      terms=[Kinetic(), AtomicLocal(), Hartree()],
+                      n_electrons=1, spin_polarization=:spinless,
+                      symmetries=false, periodicity,
+                      disable_electrostatics_check=true)
+        basis = PlaneWaveBasis(model; Ecut, kgrid=(1, 1, 1))
+        scfres = self_consistent_field(basis; tol=1e-8, callback=identity)
+
+        # Dipole moment along x relative to cell centre: d_x = ∫(x - L/2) ρ(r) dr
+        ρtot = Array(total_density(scfres.ρ))
+        x_frac = [r[1] for r in r_vectors(basis)]  # fractional x ∈ [0, 1)
+        dipole_x = sum((x_frac .- 0.5) .* ρtot) * basis.dvol * L  # in Bohr
+
+        scfres.energies.total, dipole_x
+    end
+
+    # Three box sizes: energy and dipole should be stable with truncated Coulomb
+    E15, d15 = compute_energy_dipole(15.0)
+    E20, d20 = compute_energy_dipole(20.0)
+    E25, d25 = compute_energy_dipole(25.0)
+
+    # Energy should be converged: change < 0.5 mHa between successive box sizes
+    @test abs(E20 - E15) < 5e-4
+    @test abs(E25 - E20) < 5e-4
+
+    # Dipole should be converged: change < 1 mBohr between successive box sizes
+    @test abs(d20 - d15) < 1e-3
+    @test abs(d25 - d20) < 1e-3
+
+    # Dipole should be non-zero and negative (electron pulled toward the stronger
+    # Gaussian which sits at x < L/2)
+    @test d20 < -0.01
+end


### PR DESCRIPTION
…006)

Implement isolated/semi-periodic electrostatics via the truncated Coulomb method of Rozzi et al. (Phys. Rev. B 73, 205119, 2006) for 0D and 2D slab geometries (1D wire left as error stub for a future PR).

Key changes:
- `Model` gains a `periodicity` field: a 3-tuple where each entry is `true` (fully periodic), `:wavefunctions_only` (plane-wave wavefunctions with isolated electrostatics), or `false` (reserved for future fully- isolated wavefunctions; currently identical to `:wavefunctions_only`). The constructor validates that isolated directions are orthogonal to periodic ones.
- New `src/terms/truncated_coulomb.jl`: `truncated_coulomb_radius` and `truncated_coulomb_fourier` implement the Rozzi kernels for 0D (spherical cutoff) and 2D slab (Bessel-based) cases.
- `Hartree`: `compute_poisson_green_coeffs` uses the truncated kernel instead of 4π/|G|² when `!is_fully_periodic_electrostatics(model)`.
- `AtomicLocal`: `compute_local_potential` applies a per-atom correction via `add_truncated_coulomb_ionic_correction!` that replaces the standard -Z/|G|² long-range tail with the truncated kernel (including the finite G=0 contribution V_short(0) - Z·v_c(0)).
- `Ewald`: non-periodic models use a bare direct pair sum (`energy_forces_ewald_direct`) instead of the Ewald summation — no periodic images, no compensating background.
- `PspCorrection`: returns zero energy for non-periodic models to avoid double-counting the V_short(G=0) term that is now embedded in V_ion(G=0).
- New helper predicates exported: `is_wavefunctions_periodic`, `is_electrostatics_periodic`, `n_periodic_electrostatics`, `is_fully_periodic_electrostatics`.
- `todict!` serialises the `periodicity` field.
- New test file `test/truncated_coulomb.jl` (5 test items): model periodicity field construction/validation, kernel values, direct Ewald pair sum, ionic potential G=0 value, and isolated-dipole SCF convergence.

Known limitations (TODOs in code):
- 1D wire Coulomb truncation not implemented (raises error).
- Forces for the truncated-Coulomb ionic correction not implemented.
- Phonon/dynmat and q≠0 ionic corrections not implemented.

https://claude.ai/code/session_018Y7AgeMV3ZTCA1G4CLZz4F