### PR TITLE
Safe GPU-aware MPI communication

### DIFF
--- a/src/common/mpi.jl
+++ b/src/common/mpi.jl
@@ -11,20 +11,24 @@ mpi_master(comm::MPI.Comm) = (MPI.Init(); MPI.Comm_rank(comm) == 0)
 @deprecate mpi_nprocs() mpi_nprocs(MPI.COMM_WORLD)
 @deprecate mpi_master() mpi_master(MPI.COMM_WORLD)
 
-# Wrappers around standarf MPI operations. Avoid using MPI.COMM_WORLD unless strictly necessary.
-mpi_sum(  arr, comm::MPI.Comm) = MPI.Allreduce( arr,   +, comm)
-mpi_sum!( arr, comm::MPI.Comm) = MPI.Allreduce!(arr,   +, comm)
-mpi_min(  arr, comm::MPI.Comm) = MPI.Allreduce( arr, min, comm)
-mpi_min!( arr, comm::MPI.Comm) = MPI.Allreduce!(arr, min, comm)
-mpi_max(  arr, comm::MPI.Comm) = MPI.Allreduce( arr, max, comm)
-mpi_max!( arr, comm::MPI.Comm) = MPI.Allreduce!(arr, max, comm)
+# GPU-aware MPI requires device synchronization to avoid race conditions. No overhead on CPU.
+sync(arr::AbstractGPUArray) = synchronize_device(architecture(arr))
+sync(arr) = nothing
+
+# Wrappers around standard MPI operations. Avoid using MPI.COMM_WORLD unless strictly necessary.
+mpi_sum(  arr, comm::MPI.Comm) = (sync(arr); MPI.Allreduce( arr,   +, comm))
+mpi_sum!( arr, comm::MPI.Comm) = (sync(arr); MPI.Allreduce!(arr,   +, comm))
+mpi_min(  arr, comm::MPI.Comm) = (sync(arr); MPI.Allreduce( arr, min, comm))
+mpi_min!( arr, comm::MPI.Comm) = (sync(arr); MPI.Allreduce!(arr, min, comm))
+mpi_max(  arr, comm::MPI.Comm) = (sync(arr); MPI.Allreduce( arr, max, comm))
+mpi_max!( arr, comm::MPI.Comm) = (sync(arr); MPI.Allreduce!(arr, max, comm))
 mpi_mean( arr, comm::MPI.Comm) = mpi_sum(arr, comm) ./ mpi_nprocs(comm)
 mpi_mean!(arr, comm::MPI.Comm) = (mpi_sum!(arr, comm); arr ./= mpi_nprocs(comm))
 
-mpi_bcast(arr, comm::MPI.Comm; root::Int=0) = MPI.bcast(arr, root, comm)
-mpi_bcast(arr, root::Int, comm::MPI.Comm) = MPI.bcast(arr, root, comm)
-mpi_bcast!(arr, comm::MPI.Comm; root::Int=0) = MPI.Bcast!(arr, root, comm)
-mpi_bcast!(arr, root::Int, comm::MPI.Comm) = MPI.Bcast!(arr, root, comm)
+mpi_bcast(arr, comm::MPI.Comm; root::Int=0) = (sync(arr); MPI.bcast(arr, root, comm))
+mpi_bcast(arr, root::Int, comm::MPI.Comm) = (sync(arr); MPI.bcast(arr, root, comm))
+mpi_bcast!(arr, comm::MPI.Comm; root::Int=0) = (sync(arr); MPI.Bcast!(arr, root, comm))
+mpi_bcast!(arr, root::Int, comm::MPI.Comm) = (sync(arr); MPI.Bcast!(arr, root, comm))
 mpi_barrier(comm::MPI.Comm) = MPI.Barrier(comm)
 
 @static if Base.Sys.ARCH == :aarch64


### PR DESCRIPTION
Before MPI communication of GPU buffers, the device must be synchronized. If not, there is a real risk of race condition because CPU and GPU run asynchronously. This has no effect on CPU performance. On the GPU, this cannot be avoided.

For reference, here is a [PR](https://github.com/JuliaParallel/MPI.jl/pull/949) updating the relevant documentation in MPI.jl. The problem has been known for a while, but never properly documented. The PR also links to a slack thread where the problem is discussed.